### PR TITLE
docs: point to published SDLC and unify vulnerability reporting

### DIFF
--- a/PRESIDIO-REQ.md
+++ b/PRESIDIO-REQ.md
@@ -52,3 +52,8 @@ dependencies and works on any laptop without additional services.
 `st.experimental_rerun()` (deprecated in Streamlit ≥1.28).
 
 <!-- Deliver the complete working project ready for GitHub publish. -->
+
+## SDLC
+
+These requirements are delivered under the family-wide Presidio SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/README.md
+++ b/README.md
@@ -90,3 +90,10 @@ src/presidio_ids/
 ## License
 
 MIT
+
+---
+
+## SDLC
+
+This repository is developed under the Presidio hardened-family SDLC:
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,18 @@
 
 ## Reporting a Vulnerability
 
-Do not open a public GitHub issue for security vulnerabilities.
+Please report security vulnerabilities by opening a private GitHub Security Advisory
+(via the "Security" tab → "Report a vulnerability") rather than a public issue.
 
-Email **security@presidio-group.eu** with description, reproduction steps, and impact.
-Acknowledgement within 48 hours; resolution within 7 days.
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+You will receive an acknowledgement within 5 business days. We aim to release a patch
+within 30 days of a confirmed vulnerability.
 
 ## Security Features
 
@@ -23,3 +31,9 @@ Acknowledgement within 48 hours; resolution within 7 days.
 | **Security event logging** | Structured events for fit, evaluate, save, load, and evasion |
 | **No network I/O** | Traffic is synthetic; dashboard reads local files only |
 | **Deterministic generation** | All random operations accept a seed for reproducibility |
+
+## Software Development Lifecycle
+
+This repository is developed under the Presidio hardened-family SDLC. The public report
+— scope, standards mapping, threat-model gates, and supply-chain controls — is at
+<https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md>.


### PR DESCRIPTION
## Summary

- Normalize the SECURITY.md Reporting section to the GitHub Security Advisories-only pattern (dropping the email address, matching the pattern used by `vol-assign` and `x402`).
- Add pointers to the published family SDLC in README.md, SECURITY.md, and PRESIDIO-REQ.md.
- SDLC: https://github.com/presidio-v/presidio-hardened-docs/blob/main/sdlc/sdlc-report.md

## Test plan

- [x] Diff scoped to the three docs files; no source or workflow changes
- [x] Links render on GitHub