### PR TITLE
Resolve dependency maintenance alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
       - name: Ruff format check
@@ -32,12 +32,12 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
       - name: Install dependencies
         run: uv pip install --system -e ".[dev]"
       - name: Run tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,15 +18,15 @@ jobs:
     name: Analyze (Python)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: python
           queries: security-and-quality
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "tomli; python_version < '3.11'"]
 build-backend = "hatchling.build"
 
 [project]
@@ -23,23 +23,25 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "scikit-learn>=1.4",
-    "pandas>=2.1",
-    "numpy>=1.26",
-    "joblib>=1.3",
+    "scikit-learn>=1.7.2",
+    "pandas>=2.3.3",
+    "numpy>=2.2.6",
+    "joblib>=1.5.3",
 ]
 
 [project.optional-dependencies]
 dashboard = [
-    "streamlit>=1.33",
-    "matplotlib>=3.8",
+    "streamlit>=1.56.0",
+    "tornado>=6.5.7",
+    "matplotlib>=3.10.8",
 ]
 dev = [
-    "pytest>=7.4",
-    "pytest-cov>=4.1",
-    "ruff>=0.4",
-    "streamlit>=1.33",
-    "matplotlib>=3.8",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "ruff>=0.15.10",
+    "streamlit>=1.56.0",
+    "tornado>=6.5.7",
+    "matplotlib>=3.10.8",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-scikit-learn>=1.4
-pandas>=2.1
-numpy>=1.26
-joblib>=1.3
-streamlit>=1.33
-matplotlib>=3.8
+scikit-learn>=1.7.2
+pandas>=2.3.3
+numpy>=2.2.6
+joblib>=1.5.3
+streamlit>=1.56.0
+tornado>=6.5.7
+matplotlib>=3.10.8


### PR DESCRIPTION
Summary:
- Aggregate the open Dependabot pip lower-bound updates and keep requirements.txt aligned.
- Update pinned GitHub Actions, including consistent CodeQL action pins across init/autobuild/analyze.
- Add an explicit tornado>=6.5.7 floor to clear the remaining dashboard dependency audit finding.

Test plan:
- [x] .venv/bin/python -m ruff check .
- [x] .venv/bin/python -m ruff format --check .
- [x] .venv/bin/python -m pytest tests/ -x -q --tb=short
- [x] pip-audit --path .venv/lib/python3.14/site-packages