### PR TITLE
build(deps): bump github/codeql-action to 4.37.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,10 @@ updates:
     labels:
       - dependencies
       - ci
+    groups:
+      # codeql-action's init/autobuild/analyze steps must run at the same
+      # version; separate PRs per sub-action produce a CodeQL configuration
+      # error, so they have to be bumped together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           queries: security-and-quality
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:python"


### PR DESCRIPTION
Supersedes #48, #49 and #50.

## What

Bumps all three `github/codeql-action` sub-actions in `.github/workflows/codeql.yml` from v4.37.3 (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`) to v4.37.9 (`cdf488f595d80d6e07e03d4674febd5ab45fa938`) in a single change:

- `github/codeql-action/init`
- `github/codeql-action/autobuild`
- `github/codeql-action/analyze`

## Why one PR instead of three

Dependabot opened #48, #49 and #50, each bumping one sub-action in isolation. **All three fail CI** with:

```
CodeQL job status was configuration error.
```

The `init`, `autobuild` and `analyze` steps must run at the same version — a per-sub-action bump leaves the workflow with mixed versions and is never mergeable on its own. `Analyze (Python)` is green on `main` (all three at v4.37.3) and red on each of the three PRs, which confirms the mismatch rather than the new version is the cause.

The target SHA is corroborated independently by all three Dependabot PRs, which agree on `cdf488f595d80d6e07e03d4674febd5ab45fa938` for v4.37.9. Pinning-by-SHA with a version comment is preserved.

## Preventing recurrence

Adds a `codeql-action` group to `.github/dependabot.yml` so future `github/codeql-action*` updates arrive as one PR:

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action*"
```

Besides the correctness fix, this stops the sub-actions from consuming 3 of the 5 `open-pull-requests-limit` slots for the github-actions ecosystem, which was crowding out other action updates.

## Validation

- Both changed YAML files parse cleanly.
- CI on this PR is the real check: `Analyze (Python)` should go green now that all three steps are aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvM68fwUY54Np3zGBDFxaf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvM68fwUY54Np3zGBDFxaf)_